### PR TITLE
Add support for atomics and bulk memory

### DIFF
--- a/build-wasix.sh
+++ b/build-wasix.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+# in other to build it for https://github.com/wasix-org/wasix-libc we need these flags:
+export CFLAGS=" -Xclang -target-feature -Xclang +atomics -Xclang -target-feature -Xclang +bulk-memory"
+export CPPFLAGS="-Xclang -target-feature -Xclang +atomics -Xclang -target-feature -Xclang +bulk-memory" 
+./build.sh

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,6 @@
 #! /bin/sh
 
 NPROCESSORS=$(getconf NPROCESSORS_ONLN 2>/dev/null || getconf _NPROCESSORS_ONLN 2>/dev/null)
-
 cd openssl || exit 1
 
 env \
@@ -9,7 +8,7 @@ env \
     AR="zig ar" \
     RANLIB="zig ranlib" \
     CC="zig cc --target=wasm32-wasi" \
-    CFLAGS="-Ofast -Werror -Qunused-arguments -Wno-shift-count-overflow" \
+    CFLAGS="$CFLAGS -Ofast -Werror -Qunused-arguments -Wno-shift-count-overflow" \
     CPPFLAGS="$CPPFLAGS -D_WASI_EMULATED_GETPID -Dgetuid=getpagesize -Dgeteuid=getpagesize -Dgetgid=getpagesize -Dgetegid=getpagesize" \
     CXXFLAGS="-Werror -Qunused-arguments -Wno-shift-count-overflow" \
     LDFLAGS="-s -lwasi-emulated-getpid" \


### PR DESCRIPTION
## What
In order to compile wasix libc related projects that use openssl, we need to add atomics and bulk-memory flags, so we can link this library there.

## Why
When we use wasix libc it requires atomics and/or bulk-memory support. 
So the changes I did allow us to use build-wasix.sh in order to add the support.
